### PR TITLE
后端session关闭处理

### DIFF
--- a/cluster/call.go
+++ b/cluster/call.go
@@ -9,6 +9,10 @@ import (
 	"github.com/chrislonng/starx/session"
 )
 
+var (
+	sessionClosedRoute = &route.Route{Service: "__Session", Method: "Closed"}
+)
+
 func AsyncCall(route *route.Route, session *session.Session, args ...interface{}) {
 
 }
@@ -27,4 +31,14 @@ func Call(rpcKind rpc.RpcKind, route *route.Route, session *session.Session, arg
 		return nil, errors.New(err.Error())
 	}
 	return *reply, nil
+}
+
+func SessionClosed(session *session.Session) {
+	for _, t := range svrTypes {
+		client, err := ClientByType(t, session)
+		if err != nil {
+			continue
+		}
+		err = client.Call(rpc.Sys, sessionClosedRoute.Service, sessionClosedRoute.Method, session.Entity.ID(), nil, nil)
+	}
 }

--- a/cluster/call.go
+++ b/cluster/call.go
@@ -13,10 +13,6 @@ var (
 	sessionClosedRoute = &route.Route{Service: "__Session", Method: "Closed"}
 )
 
-func AsyncCall(route *route.Route, session *session.Session, args ...interface{}) {
-
-}
-
 // Client send request
 // First argument is namespace, can be set `user` or `sys`
 func Call(rpcKind rpc.RpcKind, route *route.Route, session *session.Session, args []byte) ([]byte, error) {

--- a/cluster/rpc/client.go
+++ b/cluster/rpc/client.go
@@ -97,8 +97,10 @@ func (client *Client) send(rpcKind RpcKind, call *Call) {
 		return
 	}
 	seq := client.seq
-	client.seq++
-	client.pending[seq] = call
+	if call.Reply != nil {
+		client.seq++
+		client.pending[seq] = call
+	}
 	client.mutex.Unlock()
 
 	// Encode and send the request.

--- a/network/net.go
+++ b/network/net.go
@@ -5,11 +5,14 @@ import (
 	"net"
 	"sync"
 
+	"github.com/chrislonng/starx/cluster"
 	"github.com/chrislonng/starx/log"
 	"github.com/chrislonng/starx/network/message"
 	"github.com/chrislonng/starx/network/packet"
 	"github.com/chrislonng/starx/session"
 )
+
+const sessionClosedRoute = "__Session.Closed"
 
 var (
 	ErrSessionOnNotify = errors.New("current session working on notify mode")
@@ -187,8 +190,6 @@ func (net *netService) Session(sid uint64) (*session.Session, error) {
 
 // Close session
 func (net *netService) closeSession(session *session.Session) {
-	// TODO: notify all backend server, current session has closed.
-	// session close callback
 	net.sessionCloseCbLock.RLock()
 	if len(net.sessionCloseCb) > 0 {
 		for _, cb := range net.sessionCloseCb {
@@ -198,22 +199,27 @@ func (net *netService) closeSession(session *session.Session) {
 		}
 	}
 	net.sessionCloseCbLock.RUnlock()
+
 	if appConfig.IsFrontend {
 		net.agentMapLock.Lock()
 		if agent, ok := net.agentMap[session.Entity.ID()]; ok && (agent != nil) {
 			delete(net.agentMap, session.Entity.ID())
 		}
 		net.agentMapLock.Unlock()
-		defaultNetService.dumpAgents()
-	} /* else {
+
+		// notify all backend server, current session has been closed.
+		cluster.SessionClosed(session)
+	} else {
 		net.acceptorMapLock.RLock()
-		if acceptor, ok := net.acceptorMap[session.entityID]; ok && (acceptor != nil) {
-			// TODO: FIXED IT
-			// backend session close should not cause acceptor remove from acceptor map
+		if acceptor, ok := net.acceptorMap[session.Entity.ID()]; ok && (acceptor != nil) {
+			delete(acceptor.sessionMap, session.Id)
+			if fid, ok := acceptor.b2fMap[session.Id]; ok {
+				delete(acceptor.b2fMap, session.Id)
+				delete(acceptor.f2bMap, fid)
+			}
 		}
 		net.acceptorMapLock.RUnlock()
-		defaultNetService.dumpAcceptor()
-	}*/
+	}
 }
 
 func (net *netService) removeAcceptor(a *acceptor) {

--- a/network/remote.go
+++ b/network/remote.go
@@ -105,7 +105,7 @@ func (rs *remoteService) Handle(conn net.Conn) {
 		n, err := conn.Read(buf)
 		if err != nil {
 			log.Info("session closed(" + err.Error() + ")")
-			defaultNetService.dumpAgents()
+			defaultNetService.dumpAcceptor()
 			acceptor.close()
 			endChan <- true
 			break
@@ -125,7 +125,17 @@ func (rs *remoteService) Handle(conn net.Conn) {
 	}
 }
 
+func isSessionClosedRequest(rr *rpc.Request) bool {
+	return rr.ServiceMethod == sessionClosedRoute
+}
+
 func (rs *remoteService) processRequest(ac *acceptor, rr *rpc.Request) {
+	// session closed notify request
+	if isSessionClosedRequest(rr) {
+		defaultNetService.closeSession(ac.Session(rr.Sid))
+		return
+	}
+
 	var (
 		err      error
 		service  *service
@@ -231,10 +241,10 @@ WRITE_RESPONSE:
 
 func (rs *remoteService) call(method reflect.Method, args []reflect.Value) (rets []reflect.Value, err error) {
 	defer func() {
-		if recov := recover(); recov != nil {
-			log.Fatal("RpcCall Error: %+v", recov)
+		if rec := recover(); rec != nil {
+			log.Error("rpc call error: %+v", rec)
 			os.Stderr.Write(debug.Stack())
-			if s, ok := recov.(string); ok {
+			if s, ok := rec.(string); ok {
 				err = errors.New(s)
 			} else {
 				err = errors.New("RpcCall internal error")


### PR DESCRIPTION
1. cluster通信使用msgp作为序列化/反序列化库
2. 后端session关闭处理